### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/robpitcher/teamskill-demo/security/code-scanning/3](https://github.com/robpitcher/teamskill-demo/security/code-scanning/3)

To fix the problem, add an explicit `permissions` block to the workflow or to the specific job(s) that do not require write access. Since this workflow does not appear to need any write permissions (it checks out code, sets up environments, installs dependencies, and runs tests), a minimal `permissions` block should be used, limiting access to read-only. You can add this to the root level (to apply to all jobs unless overridden), or specifically to the `test` job (recommended by CodeQL is to use `contents: read` as a starting point). No other code changes, imports, or methods are needed—just this YAML addition.

Make the following edit to `.github/workflows/ci-tests.yml`: add

```yaml
permissions:
  contents: read
```

at the top level, after the `name:` and before the `on:` key (i.e., between lines 1 and 2).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
